### PR TITLE
Use uri-set for annotation's resources

### DIFF
--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -25,7 +25,7 @@
 (define-resource annotation ()
   :class (s-prefix "oa:Annotation")
   :properties `((:body :string ,(s-prefix "oa:hasBody"))
-                (:resource :url ,(s-prefix "oa:hasTarget")))
+                (:resource :uri-set ,(s-prefix "oa:hasTarget")))
   :has-one `((validation :via ,(s-prefix "ext:hasValidation")
                          :as "validation")
              (activity :via ,(s-prefix "slimmeraadpleegomgeving:Activiteit.genereertAnnotatie")


### PR DESCRIPTION
Annotation should always have link to designation object, but in most cases will also want to link to besluit (or other resource)
our datamodel does describe multiple resources but that's not reflected here yet
we can use uri-set but frontend should be adjusted